### PR TITLE
fix(deps): update vite to resolve GHSA-p9ff-h696-f583

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6666,9 +6666,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- Updates vite to patch arbitrary file read vulnerability via dev server WebSocket (GHSA-p9ff-h696-f583)
- Also resolves GHSA-4w7w-66w2-5vf9 and GHSA-v2wj-q39q-566r
- `npm audit` now reports 0 vulnerabilities; all non-pre-existing tests pass (8 localStorage failures are pre-existing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)