### PR TITLE
chore: repo review cleanup and doc refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Contributions are welcome! This document provides guidelines for contributing to
 
 ```bash
 # Clone the repository
-git clone https://github.com/ISMAELMARTINEZ/yourear.git
+git clone https://github.com/IsmaelMartinez/yourear.git
 cd yourear
 
 # Install dependencies

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 ISMAELMARTINEZ
+Copyright (c) 2025-2026 Ismael Martinez
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Grab headphones, open the link above, and tap "Full Test". That's it.
 To run locally:
 
 ```bash
-git clone https://github.com/ISMAELMARTINEZ/yourear.git
+git clone https://github.com/IsmaelMartinez/yourear.git
 cd yourear
 npm install
 npm run dev

--- a/docs/adr/003-test-frequencies.md
+++ b/docs/adr/003-test-frequencies.md
@@ -4,46 +4,59 @@
 Accepted
 
 ## Context
-Need to decide which frequencies to test. Clinical audiometry typically tests 125-8000 Hz at octave intervals.
+Need to decide which frequencies to test. Clinical audiometry typically tests 125–8000 Hz at octave intervals, with inter-octave frequencies (750, 1500, 3000, 6000 Hz) used when pure-tone averages fall between octaves or when more resolution is needed.
 
 ## Decision
-### Full Test (6 frequencies)
-- 250, 500, 1000, 2000, 4000, 8000 Hz
-- Duration: ~8 minutes
+Offer three test modes with different frequency coverage/time trade-offs.
 
-### Quick Test (3 frequencies)
+### Quick Test (3 frequencies, ~2 min)
 - 1000, 4000, 8000 Hz
-- Duration: ~2 minutes
+
+### Full Test (6 frequencies, ~8 min)
+- 250, 500, 1000, 2000, 4000, 8000 Hz
+
+### Detailed Test (11 frequencies, ~15 min)
+- 125, 250, 500, 750, 1000, 1500, 2000, 3000, 4000, 6000, 8000 Hz
 
 ## Rationale
 
-### Why these 6 frequencies for full test?
+### Why these frequencies?
 | Frequency | Importance |
 |-----------|------------|
+| 125 Hz | Very low bass, reproduction quality varies by headphones |
 | 250 Hz | Low frequency, vowel sounds |
 | 500 Hz | Speech range, PTA calculation |
+| 750 Hz | Inter-octave, detects narrow-band loss |
 | 1000 Hz | Reference frequency, PTA calculation |
+| 1500 Hz | Inter-octave, speech intelligibility |
 | 2000 Hz | Consonant sounds, PTA calculation |
-| 4000 Hz | First to show noise/age damage |
+| 3000 Hz | Inter-octave, noise-induced loss indicator |
+| 4000 Hz | First to show noise/age damage ("noise notch") |
+| 6000 Hz | Inter-octave, high-frequency loss |
 | 8000 Hz | High frequency indicator |
 
-### Why these 3 for quick test?
-- **1000 Hz** - Most sensitive frequency, reference standard
-- **4000 Hz** - "Noise notch" frequency, earliest age-related loss
-- **8000 Hz** - High frequency hearing indicator
+### Why these 3 for Quick Test?
+- **1000 Hz** — Most sensitive frequency, reference standard
+- **4000 Hz** — "Noise notch" frequency, earliest age-related loss
+- **8000 Hz** — High frequency hearing indicator
 
-### Why skip 125 Hz?
-- Consumer headphones often can't reproduce accurately
+### Why offer a Detailed Test?
+- Captures narrow-band losses that fall between octave frequencies
+- Better matches extended clinical audiograms
+- Useful for tinnitus frequency context (tinnitus often sits between octave points)
+
+### Why 125 Hz only in Detailed?
+- Consumer headphones often can't reproduce 125 Hz accurately
 - Less clinically significant for typical hearing issues
-- Adds time without proportional value
+- Keeps the Full Test focused on the most diagnostic frequencies
 
 ## Consequences
 ### Positive
-- Quick test catches 90% of issues in 25% of time
-- Full test matches clinical audiometry frequencies
-- PTA (Pure Tone Average) can be calculated from 500, 1000, 2000 Hz
+- Quick Test catches common issues in ~25% of Full Test time
+- Full Test matches clinical audiometry's standard octave frequencies
+- Detailed Test adds inter-octave resolution when users want it
+- PTA (Pure Tone Average) can be calculated from 500, 1000, 2000 Hz in all three modes
 
 ### Negative
-- Skip inter-octave frequencies (750, 1500, 3000, 6000 Hz)
-- May miss narrow-band hearing loss between tested frequencies
-
+- More modes = more UI/UX surface to maintain
+- Inter-octave frequencies (125, 750, 1500, 3000, 6000 Hz) stress consumer hardware limits

--- a/docs/adr/003-test-frequencies.md
+++ b/docs/adr/003-test-frequencies.md
@@ -59,4 +59,4 @@ Offer three test modes with different frequency coverage/time trade-offs.
 
 ### Negative
 - More modes = more UI/UX surface to maintain
-- Inter-octave frequencies (125, 750, 1500, 3000, 6000 Hz) stress consumer hardware limits
+- Extended frequencies (125 Hz at the low end; 750, 1500, 3000, 6000 Hz between octaves) stress consumer hardware limits

--- a/docs/adr/004-local-storage.md
+++ b/docs/adr/004-local-storage.md
@@ -36,10 +36,12 @@ Use **LocalStorage** with JSON serialization.
 ```typescript
 const STORAGE_KEY = 'yourear_profiles';
 
-function saveProfile(profile: HearingProfile): void {
+function createProfile(profile: Omit<HearingProfile, 'id'>): HearingProfile {
   const profiles = getAllProfiles();
-  profiles.push({ ...profile, id: generateId() });
+  const newProfile: HearingProfile = { ...profile, id: generateId() };
+  profiles.push(newProfile);
   localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+  return newProfile;
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "audiogram",
     "hearing-test"
   ],
-  "author": "ISMAELMARTINEZ",
+  "author": "Ismael Martinez",
   "license": "MIT",
   "devDependencies": {
     "@vitest/coverage-v8": "^4.0.15",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/src/screens/home.ts
+++ b/src/screens/home.ts
@@ -162,7 +162,7 @@ function renderAboutSection(): string {
 function renderFooter(): string {
   return `
     <footer class="footer" role="contentinfo">
-      <p>Open source project · <a href="https://github.com/ISMAELMARTINEZ/yourear" target="_blank" rel="noopener noreferrer">GitHub <span class="sr-only">(opens in new tab)</span></a></p>
+      <p>Open source project · <a href="https://github.com/IsmaelMartinez/yourear" target="_blank" rel="noopener noreferrer">GitHub <span class="sr-only">(opens in new tab)</span></a></p>
     </footer>
   `;
 }

--- a/src/screens/results.ts
+++ b/src/screens/results.ts
@@ -61,7 +61,7 @@ export function renderResults(): void {
       </nav>
       
       <footer class="footer" role="contentinfo">
-        <p>Open source project · <a href="https://github.com/ISMAELMARTINEZ/yourear" target="_blank" rel="noopener noreferrer">GitHub <span class="sr-only">(opens in new tab)</span></a></p>
+        <p>Open source project · <a href="https://github.com/IsmaelMartinez/yourear" target="_blank" rel="noopener noreferrer">GitHub <span class="sr-only">(opens in new tab)</span></a></p>
       </footer>
     </main>
   `;


### PR DESCRIPTION
- Remove stale renovate.json (Dependabot is the configured updater; having
  both risks duplicate PRs if Renovate is re-enabled on the repo)
- Fix LICENSE copyright year (2015 -> 2025-2026) and author casing
- Align GitHub URLs to canonical IsmaelMartinez casing in README,
  CONTRIBUTING, home.ts, results.ts, and package.json author field
- Update ADR 003 (test-frequencies) to document the Detailed Test mode
  and the 11 frequencies (125 Hz now tested in Detailed), superseding
  the older "skip 125 Hz" rationale
- Update ADR 004 (local-storage) code example to use the current
  createProfile(...) API (renamed from saveProfile)

https://claude.ai/code/session_01B3bEZS4bUXjYipqwUdS9zq