### PR TITLE
chore(deps): ignore vite major bumps until vite-plugin-pwa supports them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,13 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    # Block vite majors until vite-plugin-pwa accepts them upstream
+    # (peer-dep currently caps at vite ^7). Tracked in
+    # vite-pwa/vite-plugin-pwa#923.
+    ignore:
+      - dependency-name: "vite"
+        update-types:
+          - "version-update:semver-major"
     groups:
       npm-patch-and-minor:
         update-types:


### PR DESCRIPTION
PR #21 (Vite 7 -> 8) was blocked by an npm ci ERESOLVE: vite-plugin-pwa
currently peer-caps at vite ^7. The same block caused the revert in
commit 0295047 (#22). Ignore vite majors in Dependabot until upstream
vite-pwa/vite-plugin-pwa#923 is resolved to stop regenerating
unmergeable PRs.

https://claude.ai/code/session_0115N2AGs1n5jUVvoHLDkd3J