### PR TITLE
Add environmental noise meter to calibration screen

### DIFF
--- a/docs/research/future-features.md
+++ b/docs/research/future-features.md
@@ -11,6 +11,7 @@
 | **Speech-in-Noise Test** | Measure hearing in noise using Web Speech API + pink noise |
 | **Tinnitus Matcher** | Identify tinnitus frequency (100Hz-12kHz) and loudness |
 | **TypeScript 6** | Major toolchain upgrade (final JS-based compiler release) |
+| **Environmental Noise Check** | Optional mic-based ambient noise meter on the calibration screen |
 
 ---
 
@@ -31,13 +32,13 @@
 
  ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─
 
- PHASE 1 — ACCURACY & TRUST          ~8-10 hrs        🎯 Next up
+ PHASE 1 — ACCURACY & TRUST          ~6-8 hrs         🎯 In progress
  │
  │  ⏳ Vite 8 upgrade blocked on vite-plugin-pwa peer dep support
  │
- ├─► Environmental Noise Check                         ~2 hrs
- │   Use microphone to detect background noise
- │   and warn if environment is too loud (>40 dB).
+ ├─► Environmental Noise Check                         ✅ Done
+ │   Mic-based ambient noise meter on the calibration
+ │   screen; warns when peak > 40 dB SPL.
  │
  ├─► Reference Tone Calibration                        ~3-4 hrs
  │   "Adjust until this matches conversational speech"
@@ -80,13 +81,14 @@
 
 ### Phase 1 — Accuracy & Trust
 
-#### Environmental Noise Check
-**Effort:** ~2 hours
+#### Environmental Noise Check ✅
 
-Use the browser microphone API to sample ambient noise before testing:
-- Warn if background noise exceeds ~40 dB
-- Suggest quieter environment or time of day
-- Optional: continuous monitoring during test
+Implemented in `src/audio/noise-meter.ts` and surfaced on the calibration screen:
+- Optional, one-click mic check before the test
+- Live readout + running peak (approximate dB SPL)
+- Warns when peak exceeds `NOISE_WARNING_THRESHOLD_DB` (40 dB)
+- Non-blocking: user can proceed regardless
+- Uncalibrated — consumer mics can't give true SPL, good enough to flag obviously noisy rooms
 
 #### Reference Tone Calibration
 **Effort:** ~3-4 hours

--- a/src/audio/noise-meter.test.ts
+++ b/src/audio/noise-meter.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('noise-meter', () => {
+  describe('rmsToDbSpl', () => {
+    it('returns 0 for silence (rms = 0)', async () => {
+      const { rmsToDbSpl } = await import('./noise-meter');
+      expect(rmsToDbSpl(0)).toBe(0);
+    });
+
+    it('returns ~94 dB at full-scale rms (1.0)', async () => {
+      const { rmsToDbSpl } = await import('./noise-meter');
+      expect(rmsToDbSpl(1)).toBeCloseTo(94, 5);
+    });
+
+    it('returns a dB value consistent with the 94 dB offset', async () => {
+      const { rmsToDbSpl } = await import('./noise-meter');
+      // rms = 0.1 -> -20 dBFS -> 74 dB SPL
+      expect(rmsToDbSpl(0.1)).toBeCloseTo(74, 5);
+    });
+
+    it('clamps negative readings to 0 dB', async () => {
+      const { rmsToDbSpl } = await import('./noise-meter');
+      // Absurdly small rms would produce a negative dB SPL; clamp it.
+      expect(rmsToDbSpl(1e-10)).toBe(0);
+    });
+  });
+
+  describe('NOISE_WARNING_THRESHOLD_DB', () => {
+    it('is set to 40 dB per Phase 1 spec', async () => {
+      const { NOISE_WARNING_THRESHOLD_DB } = await import('./noise-meter');
+      expect(NOISE_WARNING_THRESHOLD_DB).toBe(40);
+    });
+  });
+
+  describe('startNoiseMeter', () => {
+    let originalAudioContext: typeof globalThis.AudioContext;
+    let originalMediaDevices: MediaDevices | undefined;
+
+    function createMockAnalyser(sampleValue = 0) {
+      return {
+        fftSize: 2048,
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+        getFloatTimeDomainData: vi.fn((buffer: Float32Array) => {
+          buffer.fill(sampleValue);
+        }),
+      };
+    }
+
+    function createMockSource() {
+      return {
+        connect: vi.fn(),
+        disconnect: vi.fn(),
+      };
+    }
+
+    function createMockTrack() {
+      return { stop: vi.fn() };
+    }
+
+    function installMockAudioContext(analyser: ReturnType<typeof createMockAnalyser>, source: ReturnType<typeof createMockSource>) {
+      globalThis.AudioContext = class {
+        state = 'running' as AudioContextState;
+        createMediaStreamSource = vi.fn(() => source);
+        createAnalyser = vi.fn(() => analyser);
+      } as unknown as typeof AudioContext;
+    }
+
+    beforeEach(() => {
+      vi.resetModules();
+      vi.useFakeTimers();
+      originalAudioContext = globalThis.AudioContext;
+      originalMediaDevices = navigator.mediaDevices;
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      globalThis.AudioContext = originalAudioContext;
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: originalMediaDevices,
+        configurable: true,
+      });
+    });
+
+    it('throws AudioInitError when getUserMedia is unavailable', async () => {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: undefined,
+        configurable: true,
+      });
+
+      const { startNoiseMeter } = await import('./noise-meter');
+      const { AudioInitError } = await import('./audio-context');
+      await expect(startNoiseMeter(() => {})).rejects.toBeInstanceOf(AudioInitError);
+    });
+
+    it('throws AudioInitError when permission is denied', async () => {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {
+          getUserMedia: vi.fn().mockRejectedValue(new Error('NotAllowedError')),
+        },
+        configurable: true,
+      });
+
+      const { startNoiseMeter } = await import('./noise-meter');
+      const { AudioInitError } = await import('./audio-context');
+      await expect(startNoiseMeter(() => {})).rejects.toBeInstanceOf(AudioInitError);
+    });
+
+    it('invokes the callback with samples once the meter starts', async () => {
+      const analyser = createMockAnalyser(0.1);
+      const source = createMockSource();
+      const track = createMockTrack();
+      installMockAudioContext(analyser, source);
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {
+          getUserMedia: vi.fn().mockResolvedValue({
+            getTracks: () => [track],
+          }),
+        },
+        configurable: true,
+      });
+
+      const { startNoiseMeter } = await import('./noise-meter');
+      const onSample = vi.fn();
+      const handle = await startNoiseMeter(onSample);
+
+      expect(onSample).toHaveBeenCalled();
+      const firstSample = onSample.mock.calls[0][0];
+      // rms = 0.1 -> -20 dBFS -> 74 dB SPL
+      expect(firstSample.db).toBeCloseTo(74, 0);
+      expect(firstSample.peakDb).toBeCloseTo(74, 0);
+
+      handle.stop();
+    });
+
+    it('tracks peak dB across samples', async () => {
+      const analyser = createMockAnalyser(0.01); // -> ~54 dB
+      const source = createMockSource();
+      const track = createMockTrack();
+      installMockAudioContext(analyser, source);
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {
+          getUserMedia: vi.fn().mockResolvedValue({
+            getTracks: () => [track],
+          }),
+        },
+        configurable: true,
+      });
+
+      const { startNoiseMeter } = await import('./noise-meter');
+      const samples: number[] = [];
+      const onSample = vi.fn((s: { db: number; peakDb: number }) => {
+        samples.push(s.peakDb);
+      });
+
+      const handle = await startNoiseMeter(onSample);
+
+      // Bump the measured level; peak should only ever grow.
+      analyser.getFloatTimeDomainData = vi.fn((buffer: Float32Array) => {
+        buffer.fill(0.1); // -> ~74 dB
+      });
+      vi.advanceTimersByTime(250);
+
+      analyser.getFloatTimeDomainData = vi.fn((buffer: Float32Array) => {
+        buffer.fill(0.001); // -> ~34 dB, but peak should stay high
+      });
+      vi.advanceTimersByTime(250);
+
+      const peaks = samples;
+      expect(peaks[peaks.length - 1]).toBeGreaterThanOrEqual(peaks[0]);
+      expect(peaks[peaks.length - 1]).toBeCloseTo(74, 0);
+
+      handle.stop();
+    });
+
+    it('stop() disconnects nodes and stops media tracks', async () => {
+      const analyser = createMockAnalyser(0);
+      const source = createMockSource();
+      const track = createMockTrack();
+      installMockAudioContext(analyser, source);
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {
+          getUserMedia: vi.fn().mockResolvedValue({
+            getTracks: () => [track],
+          }),
+        },
+        configurable: true,
+      });
+
+      const { startNoiseMeter } = await import('./noise-meter');
+      const handle = await startNoiseMeter(() => {});
+      handle.stop();
+
+      expect(source.disconnect).toHaveBeenCalled();
+      expect(analyser.disconnect).toHaveBeenCalled();
+      expect(track.stop).toHaveBeenCalled();
+    });
+
+    it('stop() is idempotent', async () => {
+      const analyser = createMockAnalyser(0);
+      const source = createMockSource();
+      const track = createMockTrack();
+      installMockAudioContext(analyser, source);
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {
+          getUserMedia: vi.fn().mockResolvedValue({
+            getTracks: () => [track],
+          }),
+        },
+        configurable: true,
+      });
+
+      const { startNoiseMeter } = await import('./noise-meter');
+      const handle = await startNoiseMeter(() => {});
+      handle.stop();
+      handle.stop();
+
+      expect(track.stop).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/audio/noise-meter.ts
+++ b/src/audio/noise-meter.ts
@@ -12,7 +12,7 @@
  * meter replacement.
  */
 
-import { getAudioContext, AudioInitError } from './audio-context';
+import { ensureRunning, AudioInitError } from './audio-context';
 
 /** Approximate offset that maps 0 dBFS -> ~94 dB SPL on typical consumer mics. */
 const SPL_OFFSET_DB = 94;
@@ -72,7 +72,7 @@ export async function startNoiseMeter(
     );
   }
 
-  const ctx = getAudioContext();
+  const ctx = await ensureRunning();
   const source = ctx.createMediaStreamSource(stream);
   const analyser = ctx.createAnalyser();
   analyser.fftSize = FFT_SIZE;

--- a/src/audio/noise-meter.ts
+++ b/src/audio/noise-meter.ts
@@ -1,0 +1,111 @@
+/**
+ * Environmental Noise Meter
+ *
+ * Samples ambient noise via the microphone and estimates approximate
+ * dB SPL. Used before a hearing test to warn when the room is too loud
+ * for reliable thresholds.
+ *
+ * Accuracy note: consumer microphones are not calibrated to an absolute
+ * SPL reference. The offset below is a widely-used approximation that
+ * puts typical quiet rooms around 25-35 dB and loud rooms above 60 dB,
+ * good enough to flag obviously noisy environments — not a sound-level
+ * meter replacement.
+ */
+
+import { getAudioContext, AudioInitError } from './audio-context';
+
+/** Approximate offset that maps 0 dBFS -> ~94 dB SPL on typical consumer mics. */
+const SPL_OFFSET_DB = 94;
+const SAMPLE_INTERVAL_MS = 200;
+const FFT_SIZE = 2048;
+
+/** Warning threshold above which ambient noise starts to affect test accuracy. */
+export const NOISE_WARNING_THRESHOLD_DB = 40;
+
+export interface NoiseSample {
+  /** Instantaneous approximate dB SPL. */
+  db: number;
+  /** Running peak dB SPL since meter start. */
+  peakDb: number;
+}
+
+export interface NoiseMeterHandle {
+  stop(): void;
+}
+
+/**
+ * Convert a time-domain RMS value in [0, 1] to an approximate dB SPL reading.
+ * Silence (rms = 0) is reported as 0 dB rather than -Infinity so the UI
+ * never renders an invalid number.
+ */
+export function rmsToDbSpl(rms: number): number {
+  if (rms <= 0) return 0;
+  const dbFs = 20 * Math.log10(rms);
+  return Math.max(0, dbFs + SPL_OFFSET_DB);
+}
+
+/**
+ * Start sampling ambient noise. Resolves with a handle once the microphone
+ * is live; rejects with AudioInitError if the browser doesn't support
+ * getUserMedia or the user denies permission.
+ */
+export async function startNoiseMeter(
+  onSample: (sample: NoiseSample) => void,
+): Promise<NoiseMeterHandle> {
+  if (!navigator.mediaDevices?.getUserMedia) {
+    throw new AudioInitError('Microphone access is not supported by this browser.');
+  }
+
+  let stream: MediaStream;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+      },
+    });
+  } catch (error) {
+    throw new AudioInitError(
+      'Microphone access was denied. Grant permission to check ambient noise.',
+      error,
+    );
+  }
+
+  const ctx = getAudioContext();
+  const source = ctx.createMediaStreamSource(stream);
+  const analyser = ctx.createAnalyser();
+  analyser.fftSize = FFT_SIZE;
+  source.connect(analyser);
+
+  const buffer = new Float32Array(analyser.fftSize);
+  let peakDb = 0;
+  let stopped = false;
+
+  const sample = () => {
+    if (stopped) return;
+    analyser.getFloatTimeDomainData(buffer);
+    let sumSquares = 0;
+    for (let i = 0; i < buffer.length; i++) {
+      sumSquares += buffer[i] * buffer[i];
+    }
+    const rms = Math.sqrt(sumSquares / buffer.length);
+    const db = rmsToDbSpl(rms);
+    if (db > peakDb) peakDb = db;
+    onSample({ db, peakDb });
+  };
+
+  const interval = setInterval(sample, SAMPLE_INTERVAL_MS);
+  sample();
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(interval);
+      try { source.disconnect(); } catch { /* already disconnected */ }
+      try { analyser.disconnect(); } catch { /* already disconnected */ }
+      stream.getTracks().forEach((track) => track.stop());
+    },
+  };
+}

--- a/src/screens/calibration.ts
+++ b/src/screens/calibration.ts
@@ -4,6 +4,11 @@
 
 import { getAppContainer, onClick, onChange, announce, focusMain } from '../utils/dom';
 import { playCalibrationTone, stopTone } from '../audio/tone-generator';
+import {
+  startNoiseMeter,
+  NOISE_WARNING_THRESHOLD_DB,
+  type NoiseMeterHandle,
+} from '../audio/noise-meter';
 import { getState, navigateTo, setUserAge } from '../state/app-state';
 import { startTest } from '../services/test-runner';
 
@@ -45,6 +50,27 @@ export function renderCalibration(): void {
         </div>
       </section>
 
+      <section class="card" aria-labelledby="noise-section-title">
+        <div class="calibration">
+          <h2 class="card__title justify-center" id="noise-section-title"><span aria-hidden="true">🎙️</span> Environmental Noise</h2>
+          <p id="noise-description" class="text-center text-secondary">
+            Background noise can raise your thresholds. This quick check uses your microphone to estimate how quiet your room is.
+          </p>
+
+          <button class="btn btn--secondary" id="noise-check" aria-describedby="noise-description">
+            <span aria-hidden="true">🎙️</span> Check Ambient Noise
+          </button>
+
+          <div id="noise-status" class="noise-meter" role="status" aria-live="polite" hidden>
+            <div class="noise-meter__readout">
+              <span class="noise-meter__value" id="noise-value">--</span>
+              <span class="noise-meter__unit" aria-hidden="true">dB</span>
+            </div>
+            <p class="noise-meter__message" id="noise-message"></p>
+          </div>
+        </div>
+      </section>
+
       <section class="card" aria-labelledby="headphone-section-title">
         <div class="calibration">
           <h2 class="card__title justify-center" id="headphone-section-title"><span aria-hidden="true">🎧</span> Test Your Headphones</h2>
@@ -77,13 +103,19 @@ export function renderCalibration(): void {
   `;
   
   announce(`${modeConfig.label} setup. Enter your age and test your headphones before starting.`);
-  
+
+  let noiseMeter: NoiseMeterHandle | null = null;
+  const stopNoiseMeter = () => {
+    noiseMeter?.stop();
+    noiseMeter = null;
+  };
+
   // Track age changes
   onChange('age-input', (value) => {
     const val = parseInt(value);
     setUserAge((val >= 5 && val <= 120) ? val : undefined);
   });
-  
+
   // Event bindings
   onClick('test-right', () => {
     playCalibrationTone('right');
@@ -93,12 +125,57 @@ export function renderCalibration(): void {
     playCalibrationTone('left');
     announce('Playing test tone in left ear');
   });
-  onClick('back-home', () => { 
-    stopTone(); 
-    navigateTo('home'); 
+  onClick('noise-check', async () => {
+    const button = document.getElementById('noise-check') as HTMLButtonElement | null;
+    const status = document.getElementById('noise-status');
+    const value = document.getElementById('noise-value');
+    const message = document.getElementById('noise-message');
+    if (!button || !status || !value || !message) return;
+
+    if (noiseMeter) {
+      stopNoiseMeter();
+      button.innerHTML = '<span aria-hidden="true">🎙️</span> Check Ambient Noise';
+      status.hidden = true;
+      announce('Noise check stopped');
+      return;
+    }
+
+    button.disabled = true;
+    button.innerHTML = '<span aria-hidden="true">⏳</span> Requesting microphone…';
+    try {
+      noiseMeter = await startNoiseMeter((sample) => {
+        value.textContent = sample.db.toFixed(0);
+        const noisy = sample.peakDb > NOISE_WARNING_THRESHOLD_DB;
+        status.classList.toggle('noise-meter--warning', noisy);
+        message.textContent = noisy
+          ? `Peak ${sample.peakDb.toFixed(0)} dB — louder than recommended. Try a quieter room for more reliable results.`
+          : `Peak ${sample.peakDb.toFixed(0)} dB — quiet enough for testing.`;
+      });
+      status.hidden = false;
+      button.innerHTML = '<span aria-hidden="true">⏹</span> Stop Noise Check';
+      button.disabled = false;
+      announce('Measuring ambient noise');
+    } catch (error) {
+      noiseMeter = null;
+      status.hidden = false;
+      status.classList.add('noise-meter--warning');
+      value.textContent = '--';
+      message.textContent = error instanceof Error
+        ? error.message
+        : 'Could not access microphone.';
+      button.innerHTML = '<span aria-hidden="true">🎙️</span> Check Ambient Noise';
+      button.disabled = false;
+      announce('Could not access microphone');
+    }
   });
-  onClick('begin-test', () => { 
+  onClick('back-home', () => {
     stopTone();
+    stopNoiseMeter();
+    navigateTo('home');
+  });
+  onClick('begin-test', () => {
+    stopTone();
+    stopNoiseMeter();
     // Ensure age is captured from input
     const ageInput = document.getElementById('age-input') as HTMLInputElement;
     const val = parseInt(ageInput?.value || '');

--- a/src/screens/calibration.ts
+++ b/src/screens/calibration.ts
@@ -61,7 +61,7 @@ export function renderCalibration(): void {
             <span aria-hidden="true">🎙️</span> Check Ambient Noise
           </button>
 
-          <div id="noise-status" class="noise-meter" role="status" aria-live="polite" hidden>
+          <div id="noise-status" class="noise-meter" hidden>
             <div class="noise-meter__readout">
               <span class="noise-meter__value" id="noise-value">--</span>
               <span class="noise-meter__unit" aria-hidden="true">dB</span>
@@ -143,13 +143,25 @@ export function renderCalibration(): void {
     button.disabled = true;
     button.innerHTML = '<span aria-hidden="true">⏳</span> Requesting microphone…';
     try {
+      let lastNoisy: boolean | null = null;
       noiseMeter = await startNoiseMeter((sample) => {
-        value.textContent = sample.db.toFixed(0);
+        const dbStr = sample.db.toFixed(0);
+        if (value.textContent !== dbStr) value.textContent = dbStr;
+
+        const peakStr = sample.peakDb.toFixed(0);
         const noisy = sample.peakDb > NOISE_WARNING_THRESHOLD_DB;
-        status.classList.toggle('noise-meter--warning', noisy);
-        message.textContent = noisy
-          ? `Peak ${sample.peakDb.toFixed(0)} dB — louder than recommended. Try a quieter room for more reliable results.`
-          : `Peak ${sample.peakDb.toFixed(0)} dB — quiet enough for testing.`;
+        const newMessage = noisy
+          ? `Peak ${peakStr} dB — louder than recommended. Try a quieter room for more reliable results.`
+          : `Peak ${peakStr} dB — quiet enough for testing.`;
+
+        if (message.textContent !== newMessage) {
+          message.textContent = newMessage;
+          status.classList.toggle('noise-meter--warning', noisy);
+          if (lastNoisy === null || noisy !== lastNoisy) {
+            lastNoisy = noisy;
+            announce(newMessage);
+          }
+        }
       });
       status.hidden = false;
       button.innerHTML = '<span aria-hidden="true">⏹</span> Stop Noise Check';

--- a/src/styles.css
+++ b/src/styles.css
@@ -549,6 +549,56 @@ body::before {
   margin-top: var(--spacing-md);
 }
 
+/* Environmental noise meter */
+.noise-meter {
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-md);
+  border-radius: var(--radius-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.noise-meter__readout {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: var(--spacing-xs);
+  font-family: var(--font-mono);
+}
+
+.noise-meter__value {
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: var(--accent-success);
+  transition: color var(--transition-fast);
+}
+
+.noise-meter__unit {
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.noise-meter__message {
+  margin-top: var(--spacing-sm);
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.noise-meter--warning {
+  background: rgba(251, 191, 36, 0.08);
+  border-color: rgba(251, 191, 36, 0.3);
+}
+
+.noise-meter--warning .noise-meter__value {
+  color: var(--accent-warning);
+}
+
+.noise-meter--warning .noise-meter__message {
+  color: var(--accent-warning);
+}
+
 /* Profile history */
 .profiles {
   margin-top: var(--spacing-xl);


### PR DESCRIPTION
## Summary

Adds an optional microphone-based ambient noise meter to the calibration screen that warns users when background noise exceeds recommended levels for accurate hearing testing.

### Changes

- **New module `src/audio/noise-meter.ts`**: Core noise metering functionality
  - `rmsToDbSpl()`: Converts time-domain RMS values to approximate dB SPL using a standard consumer microphone offset (94 dB)
  - `startNoiseMeter()`: Initializes microphone access, samples audio at 200ms intervals, tracks running peak dB
  - `NOISE_WARNING_THRESHOLD_DB`: Set to 40 dB per Phase 1 spec
  - Graceful error handling for missing microphone support or denied permissions

- **Updated `src/screens/calibration.ts`**: Integrated noise meter UI
  - New "Check Ambient Noise" button that toggles noise measurement
  - Live dB readout and running peak display
  - Warning state when peak exceeds 40 dB with user-friendly messaging
  - Cleanup on navigation or test start

- **Styling in `src/styles.css`**: Visual components for the noise meter
  - `.noise-meter`: Container with tertiary background
  - `.noise-meter__readout`: Large monospace dB display
  - `.noise-meter--warning`: Warning state with amber accent

- **Comprehensive test suite `src/audio/noise-meter.test.ts`**: 225 lines covering
  - RMS-to-dB conversion accuracy and edge cases
  - Microphone initialization and permission handling
  - Sample callback invocation and peak tracking
  - Proper cleanup and idempotent stop behavior

### Design Notes

- **Non-blocking**: Users can proceed with testing regardless of noise level
- **Uncalibrated**: Consumer microphones aren't SPL-calibrated, but the 94 dB offset is a widely-used approximation that reliably flags obviously noisy environments
- **Accessibility**: Proper ARIA labels, live region updates, and screen reader announcements
- **Robustness**: Disables AGC/echo cancellation/noise suppression to get raw ambient levels; handles disconnection errors gracefully

## Related issue

Closes Phase 1 — Accuracy & Trust environmental noise check task

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update

## Checklist

- [x] I have tested my changes (comprehensive unit test suite with 225 lines)
- [x] I have updated documentation (future-features.md updated to mark as complete)

https://claude.ai/code/session_01Gn2PHaFovXTyPMFLWDcba5