### PR TITLE
chore: add github-actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,11 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,5 +26,11 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    groups:
+      github-actions-patch-and-minor:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Adds the `github-actions` ecosystem to `.github/dependabot.yml` so the 4 existing workflow files get tracked for action-version bumps. Matches the portfolio standard (npm + github-actions). One of 4 PRs from a Dependabot config audit across the portfolio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)